### PR TITLE
解决:一个类存在多个表(多用户)的情况下,添加字段,多个表无法实现字段更改.此修改将表字段的比较跟表名字关联,而不是类名关联.

### DIFF
--- a/BGFMDB/libs/BG/BGDB.m
+++ b/BGFMDB/libs/BG/BGDB.m
@@ -1461,7 +1461,9 @@ static BGDB* BGdb = nil;
 -(void)ifIvarChangeForObject:(id)object ignoredKeys:(NSArray*)ignoredkeys{
     //获取缓存的属性信息
     NSCache* cache = [NSCache bg_cache];
-    NSString* cacheKey = [NSString stringWithFormat:@"%@_IvarChangeState",[object class]];
+    NSString *tableName = [object valueForKey:bg_tableNameKey];
+    tableName = tableName.length ? tableName : NSStringFromClass([object class]);
+    NSString* cacheKey = [NSString stringWithFormat:@"%@_IvarChangeState",tableName];
     id IvarChangeState = [cache objectForKey:cacheKey];
     if(IvarChangeState){
         return;


### PR DESCRIPTION
解决:一个类存在多个表(多用户)的情况下,添加字段,多个表无法实现字段更改.此修改将表字段的比较跟表名字关联,而不是类名关联.